### PR TITLE
Update gemspec to work with latest thin

### DIFF
--- a/sinatra-websocket.gemspec
+++ b/sinatra-websocket.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'eventmachine'
-  s.add_dependency 'thin', '~> 1.3.1'
-  s.add_dependency 'em-websocket', '~> 0.3.6'
+  s.add_dependency 'thin', '>= 1.3.1'
+  s.add_dependency 'em-websocket', '>= 0.3.6'
 end


### PR DESCRIPTION
I needed to update the runtime dependencies to run with the latest thin (1.5.0).

Tested and works great on latest chrome (Version 22.0.1229.79) and firefox (15.0.1).
If you accept the pull request would you please bump the gem version and push to rubygems?

Thanks,
