### PR TITLE
Lock em-websocket dependency due to latest API changes.

### DIFF
--- a/sinatra-websocket.gemspec
+++ b/sinatra-websocket.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'eventmachine'
   s.add_dependency 'thin', '>= 1.3.1'
-  s.add_dependency 'em-websocket', '>= 0.3.6'
+  s.add_dependency 'em-websocket', '= 0.3.8'
 end


### PR DESCRIPTION
Hi there!
em-websocket changed its API thus breaking sinatra-websocket.
I might soon check on what's needed and ensure compatibility with em-websocket's versions >= 0.4.0 and make another pull request but in the meantime would you accept the lock to an older (and working) version and push a patch version to rubygems?
Thanks,
