### PR TITLE
check for the existence of async.orig_callback since our callback may ex...

### DIFF
--- a/lib/sinatra-websocket.rb
+++ b/lib/sinatra-websocket.rb
@@ -7,7 +7,14 @@ module SinatraWebsocket
   class Connection < ::EventMachine::WebSocket::Connection
     class << self
       def from_env(env, options = {})
-        socket      = env[Thin::Request::ASYNC_CALLBACK].receiver
+        if env.include?('async.orig_callback')
+          callback_key = 'async.orig_callback'
+        elsif env.include?(Thin::Request::ASYNC_CALLBACK)
+          callback_key = Thin::Request::ASYNC_CALLBACK
+        else
+          raise 'Could not find an async callback in our environment!'
+        end
+        socket     = env[callback_key].receiver
         request    = request_from_env(env)
         connection = Connection.new(env, socket, :debug => options[:debug])
         yield(connection) if block_given?


### PR DESCRIPTION
Hello @simulacre,

I love this project, but I ran into some problems while using it with sinatra-synchrony. It seems that the environment key gets changed to async.orig_callback when using sinatra-synchrony, so I added this hack to get it working. I'd like it to be a bit cleaner, but this is the best I could come up with at the time.

Thanks,
Allan
